### PR TITLE
Fix sprint number when creating new branch

### DIFF
--- a/cli/run.py
+++ b/cli/run.py
@@ -802,8 +802,12 @@ class Cli:
         sprint_idx = self.select_active_sprint(res)
         sprint = res["values"][sprint_idx]
         sprint_id = sprint.get("id")
+
         sprint_name = sprint.get("name")
-        sprint_number = sprint_name.split(" ")[1]
+        sprint_number_regex = r"[1-9]+"
+        sprint_number_pattern = re.compile(sprint_number_regex)
+        sprint_number = sprint_number_pattern.search(sprint_name).group()
+
         jql = (
             "project = CFCCON "
             'AND status = "To Develop" '


### PR DESCRIPTION
This is to fix the branch name when the sprint name doesn't have the format `Sprint [1-9]+`.
With this solution, it will look for the numbers in the sprint name instead of splitting after first space.

# Bug
## Before
![image](https://github.com/user-attachments/assets/f3134370-afbb-4594-b445-398b9494a9dd)

## After
![image](https://github.com/user-attachments/assets/c43e4c12-5542-45a8-9334-a8591178bc51)
